### PR TITLE
Fix: Align Go version in workflow with go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.24.1' # Changed from 1.21
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
The GitHub Actions workflow was using Go version 1.21, while the go.mod file specified Go version 1.24.1. This mismatch was causing build failures.

This commit updates the go-version in .github/workflows/go.yml to 1.24.1 to match the version specified in go.mod, resolving the build issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build process to use Go version 1.24.1 in the GitHub Actions workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->